### PR TITLE
feat: converting existing api to drf base api.

### DIFF
--- a/lms/djangoapps/instructor/permissions.py
+++ b/lms/djangoapps/instructor/permissions.py
@@ -4,8 +4,11 @@ Permissions for the instructor dashboard and associated actions
 
 from bridgekeeper import perms
 from bridgekeeper.rules import is_staff
+from opaque_keys.edx.keys import CourseKey
+from rest_framework.permissions import BasePermission  # lint-amnesty, pylint: disable=wrong-import-order
 
 from lms.djangoapps.courseware.rules import HasAccessRule, HasRolesRule
+from openedx.core.lib.courses import get_course_by_id
 
 ALLOW_STUDENT_TO_BYPASS_ENTRANCE_EXAM = 'instructor.allow_student_to_bypass_entrance_exam'
 ASSIGN_TO_COHORTS = 'instructor.assign_to_cohorts'
@@ -72,3 +75,11 @@ perms[VIEW_DASHBOARD] = \
 ) | HasAccessRule('staff') | HasAccessRule('instructor')
 perms[VIEW_ENROLLMENTS] = HasAccessRule('staff')
 perms[VIEW_FORUM_MEMBERS] = HasAccessRule('staff')
+
+
+class InstructorPermission(BasePermission):
+    """Generic permissions"""
+    def has_permission(self, request, view):
+        course = get_course_by_id(CourseKey.from_string(view.kwargs.get('course_id')))
+        permission = getattr(view, 'custom_permission', None)
+        return request.user.has_perm(permission, course)

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -419,7 +419,7 @@ class TestInstructorAPIDenyLevels(SharedModuleStoreTestCase, LoginEnrollmentTest
             ('get_grading_config', {}),
             ('get_students_features', {}),
             ('get_student_progress_url', {'unique_student_identifier': self.user.username}),
-            ('get_student_progress_url_v2   ', {'unique_student_identifier': self.user.username}),
+            ('get_student_progress_url_v2', {'unique_student_identifier': self.user.username}),
             ('update_forum_role_membership',
              {'unique_student_identifier': self.user.email, 'rolename': 'Moderator', 'action': 'allow'}),
             ('list_forum_members', {'rolename': FORUM_ROLE_COMMUNITY_TA}),

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -164,6 +164,7 @@ INSTRUCTOR_POST_ENDPOINTS = {
     'get_proctored_exam_results',
     'get_student_enrollment_status',
     'get_student_progress_url',
+    'get_student_progress_url_v2',
     'get_students_features',
     'get_students_who_may_enroll',
     'list_background_email_tasks',
@@ -418,6 +419,7 @@ class TestInstructorAPIDenyLevels(SharedModuleStoreTestCase, LoginEnrollmentTest
             ('get_grading_config', {}),
             ('get_students_features', {}),
             ('get_student_progress_url', {'unique_student_identifier': self.user.username}),
+            ('get_student_progress_url_v2   ', {'unique_student_identifier': self.user.username}),
             ('update_forum_role_membership',
              {'unique_student_identifier': self.user.email, 'rolename': 'Moderator', 'action': 'allow'}),
             ('list_forum_members', {'rolename': FORUM_ROLE_COMMUNITY_TA}),
@@ -2938,33 +2940,37 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
 
         self.assertContains(response, already_running_status, status_code=400)
 
-    def test_get_student_progress_url(self):
+    @ddt.data('get_student_progress_url', 'get_student_progress_url_v2')
+    def test_get_student_progress_url(self, url):
         """ Test that progress_url is in the successful response. """
-        url = reverse('get_student_progress_url', kwargs={'course_id': str(self.course.id)})
+        url = reverse(url, kwargs={'course_id': str(self.course.id)})
         data = {'unique_student_identifier': self.students[0].email}
         response = self.client.post(url, data)
         assert response.status_code == 200
         res_json = json.loads(response.content.decode('utf-8'))
         assert 'progress_url' in res_json
 
-    def test_get_student_progress_url_from_uname(self):
+    @ddt.data('get_student_progress_url', 'get_student_progress_url_v2')
+    def test_get_student_progress_url_from_uname(self, url):
         """ Test that progress_url is in the successful response. """
-        url = reverse('get_student_progress_url', kwargs={'course_id': str(self.course.id)})
+        url = reverse(url, kwargs={'course_id': str(self.course.id)})
         data = {'unique_student_identifier': self.students[0].username}
         response = self.client.post(url, data)
         assert response.status_code == 200
         res_json = json.loads(response.content.decode('utf-8'))
         assert 'progress_url' in res_json
 
-    def test_get_student_progress_url_noparams(self):
+    @ddt.data('get_student_progress_url', 'get_student_progress_url_v2')
+    def test_get_student_progress_url_noparams(self, url):
         """ Test that the endpoint 404's without the required query params. """
-        url = reverse('get_student_progress_url', kwargs={'course_id': str(self.course.id)})
+        url = reverse(url, kwargs={'course_id': str(self.course.id)})
         response = self.client.post(url)
         assert response.status_code == 400
 
-    def test_get_student_progress_url_nostudent(self):
+    @ddt.data('get_student_progress_url', 'get_student_progress_url_v2')
+    def test_get_student_progress_url_nostudent(self, url):
         """ Test that the endpoint 400's when requesting an unknown email. """
-        url = reverse('get_student_progress_url', kwargs={'course_id': str(self.course.id)})
+        url = reverse(url, kwargs={'course_id': str(self.course.id)})
         response = self.client.post(url)
         assert response.status_code == 400
 

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
     path('get_anon_ids', api.get_anon_ids, name='get_anon_ids'),
     path('get_student_enrollment_status', api.get_student_enrollment_status, name="get_student_enrollment_status"),
     path('get_student_progress_url', api.get_student_progress_url, name='get_student_progress_url'),
+    path('get_student_progress_url_v2', api.StudentProgressUrl.as_view(), name='get_student_progress_url_v2'),
     path('reset_student_attempts', api.reset_student_attempts, name='reset_student_attempts'),
     path('rescore_problem', api.rescore_problem, name='rescore_problem'),
     path('override_problem_score', api.override_problem_score, name='override_problem_score'),


### PR DESCRIPTION
platform proposed changes [document](https://docs.google.com/document/d/1s-Aqbq8ohA-YG9jhrV3VCQyAUXDQgE8nq4DH7Ntr79E/edit
).

**Switch all APIs to be using DRF with standard Auth classes.**

This api seems a good candidate to update this code [get_student_progress_url](https://github.com/openedx/edx-platform/blob/63e940d65dbcd0191aa3d2865de6420d0f2b2c33/lms/djangoapps/instructor/views/api.py#L1728)
